### PR TITLE
Update Vagrant/README.md with easier VB install

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -16,7 +16,7 @@ If the installation fail see [README-highsierra.md](./README-highsierra.md).
 
 ## Objectives
 
-Once vagrant and virtualbox has been installed, it is possible to play with the
+Once vagrant and virtualbox have been installed, it is possible to play with the
 software and use it for live demo and development. It is also possible to
 create a bootable CD for installation on VMware, or replace the vagrant up test
 data with a copy of the production data.
@@ -56,13 +56,13 @@ Accessing the system may be done with
 The following limitations apply
 **if you are not running with VPN towards our production environment**
 
-  - The graphs in the web-gui is empty as there is no fastnetmon instances
+  - The graphs in the web-gui are empty as there are no fastnetmon instances
     sending rules to the test system, nor is it possible to
-    query any fastnetmon / influxd for network data.
+    query any fastnetmon / influxDB for network data.
   - There is no
     [looking glass](https://www.noction.com/blog/bgp-looking-glass-servers)
     server running (lg.TLD) and only one exabgp installed, so the `fnmcfg`
     fails to check if the announced rules are enforced.
   - Currently pgpool2 is not configured
-  - Probably a lot of other thing I've forgot
+  - Probably a lot of other thing I've forgotten
 

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -8,6 +8,12 @@ Quick start of DDPS using vagrant / virtualbox:
 
 If the installation fail see [README-highsierra.md](./README-highsierra.md).
 
+## Easy Install VirtualBox on Mac OS X High Sierra
+
+- Download install package from [VB for Mac OS X](https://www.virtualbox.org/wiki/Downloads).
+- Open the downloaded .dmg file and double click VirtualBox.pkg to install.
+- At the end of installation if it says the installation failed follow this [troubleshoot guide](https://matthewpalmer.net/blog/2017/12/10/install-virtualbox-mac-high-sierra/index.html) to allow system software from Oracle Corp to load and complete the installation.
+
 ## Objectives
 
 Once vagrant and virtualbox has been installed, it is possible to play with the


### PR DESCRIPTION
Added a section to install VB easily on mac os x.
I wasn't able to test intall scripts locally cause VB won't intall correctly.
Some user's might encounter the same issue while installing VB on their lates Mac OS X.

The article at the end of the list helped me fix the security checks to allow VB to install correctly on Mac OS X High Sierra.  I'm quite sure this security check may also block VB install on other lower version os Mac OS X.